### PR TITLE
updated templates so that indentation is correct.

### DIFF
--- a/ftplugin/slurper.vim
+++ b/ftplugin/slurper.vim
@@ -17,7 +17,7 @@ nmap <buffer> <C-h>
       \o
       \<C-D>==
       \<CR>story_type:
-      \<CR>chore
+      \<CR>  chore
       \<CR>name:
       \<CR><C-D>  
       \<CR>description:
@@ -38,15 +38,15 @@ nmap <buffer> <C-j>
       \o
       \<C-D>==
       \<CR>story_type:
-      \<CR>feature
+      \<CR>  feature
       \<CR>name:
       \<CR><C-D>  
       \<CR>description:
-      \<CR>In order to
-      \<CR>As a
-      \<CR>I want
+      \<CR>  In order to
+      \<CR>  As a
+      \<CR>  I want
       \<CR>
-      \<CR>-
+      \<CR>  -
       \<CR>
       \<CR>labels:
       \<CR><C-D>  
@@ -63,7 +63,7 @@ nmap <buffer> <C-k>
       \o
       \<C-D>==
       \<CR>story_type:
-      \<CR>release
+      \<CR>  release
       \<CR>name:
       \<CR><C-D>  
       \<CR>description:
@@ -84,7 +84,7 @@ nmap <buffer> <C-l>
       \o
       \<C-D>==
       \<CR>story_type:
-      \<CR>bug
+      \<CR>  bug
       \<CR>name:
       \<CR><C-D>  
       \<CR>description:
@@ -108,3 +108,4 @@ endfunction
 function! SlurperFoldExpr()
   return getline(v:lnum) == '==' ? ">1" : getline(v:lnum)!~'=='
 endfunction
+


### PR DESCRIPTION
love the slurper gem and the corresponding vim plugin. 

the problem for me was none of the predefined templates worked. In other words where two space indication was required, the templates generated from the hot-keys did not generate them. I modified the templates were required and now all story types are properly formatted from the home row commands (cmd+h ... l).

Thanks,

don
